### PR TITLE
몬스터 점프기능 추가

### DIFF
--- a/Assets/1.Scenes/MainScene.unity
+++ b/Assets/1.Scenes/MainScene.unity
@@ -1188,7 +1188,7 @@ GameObject:
   - component: {fileID: 1489341059}
   - component: {fileID: 1489341060}
   - component: {fileID: 1489341062}
-  - component: {fileID: 1489341061}
+  - component: {fileID: 1489341063}
   m_Layer: 8
   m_Name: Truck
   m_TagString: Player
@@ -1225,11 +1225,38 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b6cf2a47a53dabf418d361c73772e04e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _limitVelocity: 2.5
-  _accelPower: 1.5
-  _brakeVelocity: 0.13
---- !u!70 &1489341061
-CapsuleCollider2D:
+  _limitVelocity: 3
+  _accelPower: 1.2
+  _brakeVelocity: 0.1
+--- !u!50 &1489341062
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1489341058}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 20
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 6200000, guid: d8dba0ea762db904797f35cd87e183ca, type: 2}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!61 &1489341063
+BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -1260,36 +1287,19 @@ CapsuleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.23229085, y: -1.0999583}
-  m_Size: {x: 1.8881773, y: 0.57641774}
-  m_Direction: 1
---- !u!50 &1489341062
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1489341058}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 20
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 6200000, guid: d8dba0ea762db904797f35cd87e183ca, type: 2}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 4
+  m_Offset: {x: -0.25203276, y: -1.0957943}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.9774485, y: 0.57921505}
+  m_EdgeRadius: 0
 --- !u!1001 &1544987788
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/1.Scenes/MainScene.unity
+++ b/Assets/1.Scenes/MainScene.unity
@@ -174,6 +174,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3175506883567667195, guid: 5adc49a3cd414458b96cda173bbaeffb, type: 3}
+      propertyPath: m_BodyType
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6628118391875189848, guid: 5adc49a3cd414458b96cda173bbaeffb, type: 3}
       propertyPath: m_Name
       value: Box (4)
@@ -248,6 +252,10 @@ PrefabInstance:
     - target: {fileID: 360675798204360400, guid: 5adc49a3cd414458b96cda173bbaeffb, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3175506883567667195, guid: 5adc49a3cd414458b96cda173bbaeffb, type: 3}
+      propertyPath: m_BodyType
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5470163909460436904, guid: 5adc49a3cd414458b96cda173bbaeffb, type: 3}
       propertyPath: m_IsActive
@@ -328,6 +336,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3175506883567667195, guid: 5adc49a3cd414458b96cda173bbaeffb, type: 3}
+      propertyPath: m_BodyType
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6628118391875189848, guid: 5adc49a3cd414458b96cda173bbaeffb, type: 3}
       propertyPath: m_Name
       value: Box (2)
@@ -377,7 +389,7 @@ Transform:
   m_GameObject: {fileID: 449854377}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 14.54, y: -2.4499998, z: 10}
+  m_LocalPosition: {x: 4.58, y: -2.4499998, z: 10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -395,7 +407,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fff1e9b1db295484f95bde23501b5c7b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _spawnCoolTime: 1.5
+  _spawnCoolTime: 3
 --- !u!1 &478636166
 GameObject:
   m_ObjectHideFlags: 0
@@ -874,6 +886,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3175506883567667195, guid: 5adc49a3cd414458b96cda173bbaeffb, type: 3}
+      propertyPath: m_BodyType
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6628118391875189848, guid: 5adc49a3cd414458b96cda173bbaeffb, type: 3}
       propertyPath: m_Name
       value: Box (1)
@@ -1209,9 +1225,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b6cf2a47a53dabf418d361c73772e04e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _limitVelocity: 1.2
-  _accelPower: 9
-  _brakeVelocity: 0.16
+  _limitVelocity: 2.5
+  _accelPower: 1.5
+  _brakeVelocity: 0.13
 --- !u!70 &1489341061
 CapsuleCollider2D:
   m_ObjectHideFlags: 0
@@ -1221,7 +1237,7 @@ CapsuleCollider2D:
   m_GameObject: {fileID: 1489341058}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: d8dba0ea762db904797f35cd87e183ca, type: 2}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0
@@ -1263,7 +1279,7 @@ Rigidbody2D:
   m_LinearDrag: 0
   m_AngularDrag: 0.05
   m_GravityScale: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: d8dba0ea762db904797f35cd87e183ca, type: 2}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0
@@ -1324,6 +1340,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 175888370978376783, guid: 39e73014526a04149a4b4bff2302893b, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6718594211823800976, guid: 39e73014526a04149a4b4bff2302893b, type: 3}
+      propertyPath: m_BodyType
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8958240697474582917, guid: 39e73014526a04149a4b4bff2302893b, type: 3}
@@ -1703,6 +1723,10 @@ PrefabInstance:
     - target: {fileID: 360675798204360400, guid: 5adc49a3cd414458b96cda173bbaeffb, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3175506883567667195, guid: 5adc49a3cd414458b96cda173bbaeffb, type: 3}
+      propertyPath: m_BodyType
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6628118391875189848, guid: 5adc49a3cd414458b96cda173bbaeffb, type: 3}
       propertyPath: m_Name

--- a/Assets/2.Scripts/Character/BoxObject.cs
+++ b/Assets/2.Scripts/Character/BoxObject.cs
@@ -19,6 +19,9 @@ public class BoxObject : MonoBehaviour, IDamageable
         return false;
     }
 
+    /// <summary>
+    /// 파괴 절차 과정을 수행합니다.
+    /// </summary>
     private IEnumerator StartDestroy()
     {
         // 애니메이션 동작

--- a/Assets/2.Scripts/Character/FixedObject.cs
+++ b/Assets/2.Scripts/Character/FixedObject.cs
@@ -4,23 +4,51 @@ using UnityEngine;
 public class FixedObject : MonoBehaviour
 {
     private float _fixedLocalPosX;
-    private float _fixDuration = 1f;
+    private Rigidbody2D _rb;
+
+    private void Awake()
+    {
+        _rb = GetComponent<Rigidbody2D>();
+    }
 
     private void Start()
     {
         _fixedLocalPosX = transform.localPosition.x;
+
+        Fix();
     }
 
     /// <summary>
-    /// 오브젝트가 떨어지는 동안 물체의 위치를 보정합니다.
+    /// 해당 오브젝트의 로컬 좌표 X축을 고정시킵니다.
     /// </summary>
     public void Fix()
+    {
+        StartCoroutine(StartFix());
+    }
+
+    /// <summary>
+    /// 물체가 중력의 영향을 받을 수 있게 설정합니다.
+    /// </summary>
+    public void Drop()
     {
         if (isActiveAndEnabled == false)
             return;
 
-        StopCoroutine(StartFix());
-        StartCoroutine(StartFix());
+        _rb.isKinematic = false;
+
+        StopCoroutine(ConvertKinetic());
+        StartCoroutine(ConvertKinetic());
+    }
+
+    /// <summary>
+    /// N 초 뒤 다시 Kinetic Mode 로 전환합니다.
+    /// </summary>
+    /// <returns></returns>
+    private IEnumerator ConvertKinetic()
+    {
+        yield return new WaitForSeconds(1f);
+
+        _rb.isKinematic = true;
     }
 
     /// <summary>
@@ -28,17 +56,10 @@ public class FixedObject : MonoBehaviour
     /// </summary>
     private IEnumerator StartFix()
     {
-        float time = _fixDuration;
-
         while (true)
         {
-            if (_fixDuration <= 0)
-                break;
-
             transform.localPosition = new Vector2(_fixedLocalPosX, transform.localPosition.y);
-
             yield return null;
-            _fixDuration -= Time.deltaTime;
         }
     }
 
@@ -47,9 +68,10 @@ public class FixedObject : MonoBehaviour
     /// </summary>
     private void OnDestroy()
     {
-        if(this.transform.parent.TryGetComponent<LinkObjController>(out LinkObjController controller))
+        if (transform.parent.TryGetComponent<LinkObjController>(out LinkObjController controller))
         {
             controller.SendDestroySignal(this);
         }
+        StopAllCoroutines();
     }
 }

--- a/Assets/2.Scripts/Character/LinkObjController.cs
+++ b/Assets/2.Scripts/Character/LinkObjController.cs
@@ -46,7 +46,7 @@ public class LinkObjController : MonoBehaviour
                 {
                     if (tempNode == null) break; // 임시노드가 없다면 중단
 
-                    tempNode.Value.Fix(); // 대상 노드 오브젝트를 고정
+                    tempNode.Value.Drop(); // 대상 노드 오브젝트를 떨어지게
 
                     tempNode = tempNode.Next; // 다음 노드로 전환
                 }

--- a/Assets/3.Prefabs/Box/Box.prefab
+++ b/Assets/3.Prefabs/Box/Box.prefab
@@ -498,7 +498,7 @@ Rigidbody2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6628118391875189848}
-  m_BodyType: 0
+  m_BodyType: 1
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
@@ -529,7 +529,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d4557e4a06176124b92f617472be03b2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _upperObj: {fileID: 0}
 --- !u!1 &6872163726244765423
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/3.Prefabs/Monster/Melee.prefab
+++ b/Assets/3.Prefabs/Monster/Melee.prefab
@@ -66,7 +66,7 @@ CapsuleCollider2D:
   m_GameObject: {fileID: 319310827380095937}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: d8dba0ea762db904797f35cd87e183ca, type: 2}
   m_IncludeLayers:
     serializedVersion: 2
     m_Bits: 0
@@ -107,7 +107,7 @@ Rigidbody2D:
   m_Mass: 1
   m_LinearDrag: 0
   m_AngularDrag: 0.05
-  m_GravityScale: 1
+  m_GravityScale: 2
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2
@@ -131,6 +131,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0493c35a3150b4c4b899e8c8130a60b7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _liftPower: 21
 --- !u!1 &2094693183665648150
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/3.Prefabs/Monster/Range.prefab
+++ b/Assets/3.Prefabs/Monster/Range.prefab
@@ -106,7 +106,7 @@ Rigidbody2D:
   m_Mass: 1
   m_LinearDrag: 0
   m_AngularDrag: 0.05
-  m_GravityScale: 1
+  m_GravityScale: 2
   m_Material: {fileID: 0}
   m_IncludeLayers:
     serializedVersion: 2

--- a/Assets/5.Materials.meta
+++ b/Assets/5.Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 31471caab4063944793cd2283d41f4c8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/5.Materials/NoFriction.physicsMaterial2D
+++ b/Assets/5.Materials/NoFriction.physicsMaterial2D
@@ -1,0 +1,11 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!62 &6200000
+PhysicsMaterial2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: NoFriction
+  friction: 0
+  bounciness: 0.2

--- a/Assets/5.Materials/NoFriction.physicsMaterial2D.meta
+++ b/Assets/5.Materials/NoFriction.physicsMaterial2D.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d8dba0ea762db904797f35cd87e183ca
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 6200000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
후방 몬스터를 감지해 위쪽 방향으로 이동시키는 방식을 고려
velocity 를 활용하려 했으나 부자연스러운 연출로 인해 AddForce를 활용해 점프 방식으로 변경

플레이어 트럭 오브젝트 고정방식으로 변경
몬스터 접촉 시 뒤로 밀리는 현상을 수정하기 위해 오브젝트가 활성화 되어 있는동안
물체의 위치를 고정시키는 방식으로 수정